### PR TITLE
fix: bump axios (CVE-2026-40175)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@issuu/issuu-api-sdk",
-    "version": "0.0.22",
-    "type": "module",
-    "license": "MIT",
-    "scripts": {
-        "test": "jest --runInBand"
-    },
-    "dependencies": {
-        "axios": "^1.6.8",
-        "dotenv": "^16.4.5"
-    },
-    "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.30",
-        "jest": "^29.7.0",
-        "ts-jest": "^29.1.2",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.4.3"
-    }
+  "name": "@issuu/issuu-api-sdk",
+  "version": "0.0.22",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "axios": "^1.15.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
+  }
 }


### PR DESCRIPTION
Bumps axios to safe version (`1.15.0` for 1.x, `0.31.0` for 0.x).

**CVE-2026-40175:** CRLF header injection allows Prototype Pollution to escalate to RCE (CVSS 9.9).
**Advisory:** https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx